### PR TITLE
Removed stopping of puppetmaster

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -35,11 +35,10 @@ class puppet::master (
     content => template('puppet/puppetmaster_sysconfig.erb'),
   }
 
-#  service { 'puppetmaster':
-#    ensure => stopped,
-#    enable => false,
-#    before => File['puppetmaster_vhost'],
-#  }
+  # This cannot be stopped, would break bootstrapping.
+  service { 'puppetmaster':
+    enable => false,
+  }
 
   # Passenger
   common::mkdir_p { $rack_dir: }


### PR DESCRIPTION
Since stopping the service would break bootstrapping, this service can't
be stopped, but can be disabled.
