### PR TITLE
Differentiate between Dashboard server and not.

### DIFF
--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -1,67 +1,42 @@
 # == Class: puppet::dashboard
 #
 class puppet::dashboard (
-  $dashboard_package     = 'puppet-dashboard',
-  $database_config_path  = '/usr/share/puppet-dashboard/config/database.yml',
-  $database_config_owner = 'puppet-dashboard',
-  $database_config_group = 'puppet-dashboard',
-  $database_config_mode  = '0640',
-  $dashboard_fqdn        = "puppet.${::domain}",
-  $htpasswd              = undef,
-  $htpasswd_path         = '/etc/puppet/dashboard.htpasswd',
-  $port                  = '3000',
-  $log_dir               = '/var/log/puppet',
-  $mysql_user            = 'dashboard',
-  $mysql_password        = 'puppet',
-  $mysql_max_packet_size = '32M',
-  $security              = 'none',
+  $dashboard_package         = 'puppet-dashboard',
+  $database_config_path      = '/usr/share/puppet-dashboard/config/database.yml',
+  $database_config_owner     = 'puppet-dashboard',
+  $database_config_group     = 'puppet-dashboard',
+  $database_config_mode      = '0640',
+  $dashboard_user            = 'puppet-dashboard',
+  $dashboard_group           = 'puppet-dashboard',
+  $external_node_script_path = '/usr/share/puppet-dashboard/bin/external_node',
+  $dashboard_fqdn            = "puppet.${::domain}",
+  $htpasswd                  = undef,
+  $htpasswd_path             = '/etc/puppet/dashboard.htpasswd',
+  $port                      = '3000',
+  $log_dir                   = '/var/log/puppet',
+  $mysql_user                = 'dashboard',
+  $mysql_password            = 'puppet',
+  $mysql_max_packet_size     = '32M',
+  $security                  = 'none',
 ) {
 
+  validate_absolute_path($external_node_script_path)
   validate_absolute_path($htpasswd_path)
   validate_re($security, '^(none|htpasswd)$', "Security is <${security}> which does not match regex. Valid values are none and htpasswd.")
-
-  require 'passenger'
-  include puppet::dashboard::maintenance
-
-  class { 'mysql::server':
-    config_hash => { 'max_allowed_packet' => $mysql_max_packet_size }
-  }
 
   package { 'puppet_dashboard':
     ensure => present,
     name   => $dashboard_package,
   }
 
-  if $security == 'htpasswd' and $htpasswd != undef {
-
-    Htpasswd {
-      target => $htpasswd_path,
-    }
-
-    create_resources('htpasswd',$htpasswd)
-  }
-
-  file { 'database_config':
+  file { 'external_node_script':
     ensure  => file,
-    content => template('puppet/database.yml.erb'),
-    path    => $database_config_path,
-    owner   => $database_config_owner,
-    group   => $database_config_group,
-    mode    => $database_config_mode,
+    content => template('puppet/external_node.erb'),
+    path    => $external_node_script_path,
+    owner   => $dashboard_user,
+    group   => $dashboard_group,
+    mode    => '0755',
     require => Package['puppet_dashboard'],
-  }
-
-  file { 'dashboard_vhost':
-    ensure  => file,
-    path    => '/etc/httpd/conf.d/dashboard.conf',
-    content => template('puppet/dashboard-vhost.conf.erb'),
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    require => [ File['httpd_vdir'],       # apache
-#                Exec['compile-passenger'], # passenger
-                ],
-    notify  => Service['httpd'],           # apache
   }
 
   file { 'dashboard_sysconfig':
@@ -73,25 +48,6 @@ class puppet::dashboard (
     mode    => '0644',
   }
 
-  mysql::db { 'dashboard':
-    user     => $mysql_user,
-    password => $mysql_password,
-    host     => 'localhost',
-    grant    => ['all'],
-    require  => [ Class['mysql::server'],
-                  File['database_config'],
-                ],
-  }
-
-  exec { 'migrate_dashboard_database':
-    command     => 'rake RAILS_ENV=production db:migrate',
-    onlyif      => 'rake RAILS_ENV=production db:version 2>/dev/null|grep ^\'Current version\' | awk -F : \'{print $2}\' | awk \'{print $1}\'|grep ^0$',
-    path        => '/bin:/usr/bin:/sbin:/usr/sbin',
-    cwd         => '/usr/share/puppet-dashboard',
-    refreshonly => true,
-    subscribe   => Mysql::Db['dashboard'],
-  }
-
   # Dashboard is ran under Passenger with Apache
   service { 'puppet-dashboard':
     ensure    => stopped,
@@ -100,8 +56,7 @@ class puppet::dashboard (
   }
 
   service { 'puppet-dashboard-workers':
-    ensure    => running,
-    enable    => true,
-    subscribe => File['dashboard_sysconfig'],
+    ensure    => stopped,
+    enable    => false,
   }
 }

--- a/manifests/dashboard/server.pp
+++ b/manifests/dashboard/server.pp
@@ -1,0 +1,68 @@
+# == Class: puppet::dashboard::server
+#
+class puppet::dashboard::server inherits puppet::dashboard {
+
+  require 'passenger'
+  include puppet::dashboard::maintenance
+
+  class { 'mysql::server':
+    config_hash => { 'max_allowed_packet' => $mysql_max_packet_size }
+  }
+
+  if $security == 'htpasswd' and $htpasswd != undef {
+
+    Htpasswd {
+      target => $htpasswd_path,
+    }
+
+    create_resources('htpasswd',$htpasswd)
+  }
+
+  file { 'database_config':
+    ensure  => file,
+    content => template('puppet/database.yml.erb'),
+    path    => $database_config_path,
+    owner   => $database_config_owner,
+    group   => $database_config_group,
+    mode    => $database_config_mode,
+    require => Package['puppet_dashboard'],
+  }
+
+  file { 'dashboard_vhost':
+    ensure  => file,
+    path    => '/etc/httpd/conf.d/dashboard.conf',
+    content => template('puppet/dashboard-vhost.conf.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require => [ File['httpd_vdir'],       # apache
+#                Exec['compile-passenger'], # passenger
+                ],
+    notify  => Service['httpd'],           # apache
+  }
+
+  mysql::db { 'dashboard':
+    user     => $mysql_user,
+    password => $mysql_password,
+    host     => 'localhost',
+    grant    => ['all'],
+    require  => [ Class['mysql::server'],
+                  File['database_config'],
+                ],
+  }
+
+  exec { 'migrate_dashboard_database':
+    command     => 'rake RAILS_ENV=production db:migrate',
+    onlyif      => 'rake RAILS_ENV=production db:version 2>/dev/null|grep ^\'Current version\' | awk -F : \'{print $2}\' | awk \'{print $1}\'|grep ^0$',
+    path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+    cwd         => '/usr/share/puppet-dashboard',
+    refreshonly => true,
+    subscribe   => Mysql::Db['dashboard'],
+  }
+
+  Service['puppet-dashboard-workers'] {
+    ensure    => running,
+    enable    => true,
+    subscribe => File['dashboard_sysconfig'],
+  }
+}

--- a/templates/external_node.erb
+++ b/templates/external_node.erb
@@ -1,0 +1,52 @@
+#! /usr/bin/ruby
+#
+# This file is being maintained by Puppet.
+# DO NOT EDIT
+#
+# Sample External Node script for Puppet Dashboard
+#
+# == puppet.conf Configuration
+#
+#  [main]
+#  external_nodes = /path/to/external_node
+#  node_terminus = exec
+
+require 'yaml'
+require 'uri'
+require 'net/http'
+
+DASHBOARD_URL = "http://<%= @dashboard_fqdn %>:<%= @port %>"
+
+# These settings are only used when connecting to dashboard over https (SSL)
+CERT_PATH = "/etc/puppet/ssl/certs/puppet.pem"
+PKEY_PATH = "/etc/puppet/ssl/private_keys/puppet.pem"
+CA_PATH   = "/etc/puppet/ssl/certs/ca.pem"
+
+cert_path = ENV['PUPPET_CERT_PATH'] || CERT_PATH
+pkey_path = ENV['PUPPET_PKEY_PATH'] || PKEY_PATH
+ca_path   = ENV['PUPPET_CA_PATH']   || CA_PATH
+
+NODE = ARGV.first
+
+url = ENV['PUPPET_DASHBOARD_URL'] || DASHBOARD_URL
+uri = URI.parse("#{url}/nodes/#{NODE}")
+require 'net/https' if uri.scheme == 'https'
+
+request = Net::HTTP::Get.new(uri.path, initheader = {'Accept' => 'text/yaml'})
+request.basic_auth uri.user, uri.password if uri.user
+http = Net::HTTP.new(uri.host, uri.port)
+if uri.scheme == 'https'
+  cert = File.read(cert_path)
+  pkey = File.read(pkey_path)
+  http.use_ssl = true
+  http.cert = OpenSSL::X509::Certificate.new(cert)
+  http.key = OpenSSL::PKey::RSA.new(pkey)
+  http.ca_file = ca_path
+  http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+end
+result = http.start {|http| http.request(request)}
+
+case result
+when Net::HTTPSuccess; puts result.body; exit 0
+else; STDERR.puts "Error: #{result.code} #{result.message.strip}\n#{result.body}"; exit 1
+end


### PR DESCRIPTION
One system is the Dashboard server, while other systems need
puppet-dashboard installed, so they can query the Dashboard server as an
external node classifier.
