### PR TITLE
Note needed sudoers entry in README for cron jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Dashboard
 - Calls the `puppet::dashboard::maintenance` class
 - Creates database for puppet with mysql module
 - Maintenance to clean up old reports, optimize database and dump database
+- For the maintenance cron jobs, you should have the following line in your `/etc/sudoers` which is not managed with this module.
+<pre>
+Defaults:root !requiretty
+</pre>
 
 Lint
 ----


### PR DESCRIPTION
Without this line in the sudoers file, the cron jobs relating to the
maintenance of the dashboard may fail. This commit alerts the module
user.
