### PR TITLE
Don't add sysconfig file to Solaris

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ Whether the client should run right after boot
 
 agent_sysconfig
 ---------------
-The location of the /etc/sysconfig/puppet file.
+The location of the /etc/sysconfig/puppet file. If set to undef, this file will not be managed.
 
-- *Default*: /etc/sysconfig/puppet
+- *Default*: DEFAULT
 
 daemon_name
 -----------

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -16,17 +16,25 @@ describe 'puppet::agent' do
       }
     end
 
-    context 'Puppet agent sysconfig' do
-      let(:params) { {:env => 'production' } }
-      it {
-        should include_class('puppet::agent')
-        should contain_file('puppet_agent_sysconfig').with({
-          'path'    => '/etc/sysconfig/puppet',
-          'owner'   => 'root',
-          'group'   => 'root',
-          'mode'    => '0644',
-        })
-      }
+    describe 'Puppet agent sysconfig' do
+
+      context 'on Linux' do
+        let(:facts) { {:osfamily => 'RedHat' } }
+        let(:params) {
+          {:env => 'production',
+           :agent_sysconfig => 'DEFAULT'}
+        }
+        it {
+          should include_class('puppet::agent')
+          should contain_file('puppet_agent_sysconfig').with({
+            'path'    => '/etc/sysconfig/puppet',
+            'owner'   => 'root',
+            'group'   => 'root',
+            'mode'    => '0644',
+          })
+        }
+      end
+
     end
 
     context 'Puppet agent sysconfig content' do


### PR DESCRIPTION
Adds conditional logic to avoid trying to add /etc/sysconfig/puppet to a Solaris host.
