### PR TITLE
Only define Cron['puppet_agent_once_at_boot'] if $run_method == 'cron'

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -123,10 +123,12 @@ class puppet::agent (
     minute  => $cron_minute,
   }
 
-  cron { 'puppet_agent_once_at_boot':
-    ensure  => $at_boot_ensure,
-    command => $my_cron_command,
-    user    => $cron_user,
-    special => 'reboot',
+  if $run_method == 'cron' {
+    cron { 'puppet_agent_once_at_boot':
+      ensure  => $at_boot_ensure,
+      command => $my_cron_command,
+      user    => $cron_user,
+      special => 'reboot',
+    }
   }
 }


### PR DESCRIPTION
On a new RHEL 6.4 system the following error occurs
"-":6: bad command
errors in crontab file, can't install.
