### PR TITLE
Fixed: hardcoded cron_command when run_in_noop is active

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -93,7 +93,7 @@ class puppet::agent (
       $cron_ensure   = 'present'
       case $run_in_noop {
         'true': {
-          $my_cron_command = '/usr/bin/puppet agent --onetime --ignorecache --no-daemonize --no-usecacheonfailure --detailed-exitcodes --no-splay --noop'
+          $my_cron_command = "${cron_command} --noop"
         }
         'false': {
           $my_cron_command = $cron_command


### PR DESCRIPTION
fixes issue https://github.com/ghoneycutt/puppet-module-puppet/issues/40
hardcoded "noop" command changed against "${cron_command} --noop"
