### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 env:
-- PUPPET_VERSION=2.7.22
-- PUPPET_VERSION=3.3.1
+- PUPPET_VERSION=2.7.23
+- PUPPET_VERSION=3.3.2
 notifications:
 email: false
 rvm:
@@ -9,7 +9,7 @@ rvm:
 - 1.8.7
 matrix:
   allow_failures:
-  - env: PUPPET_VERSION=2.7.22
+  - env: PUPPET_VERSION=2.7.23
 language: ruby
 before_script: "gem install --no-ri --no-rdoc bundler"
 script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,13 @@ PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Run puppet in noop mode and check for syntax errors."
 task :validate do
-   Dir['manifests/**/*.pp'].each do |path|
-     sh "puppet parser validate --noop #{path}"
-   end
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
 end

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -11,7 +11,7 @@ describe 'puppet::agent' do
       end
       let(:params) { { :env => 'production' } }
 
-      it { should include_class('puppet::agent') }
+      it { should contain_class('puppet::agent') }
 
       it { should contain_file('puppet_config').with({
           'path'    => '/etc/puppet/puppet.conf',
@@ -44,7 +44,7 @@ describe 'puppet::agent' do
       let(:facts) { { :osfamily => 'RedHat' } }
       let(:params) { { :env => 'production' } }
 
-      it { should include_class('puppet::agent') }
+      it { should contain_class('puppet::agent') }
 
       it { should contain_file('puppet_agent_sysconfig').with({
           'path'    => '/etc/sysconfig/puppet',
@@ -65,7 +65,7 @@ describe 'puppet::agent' do
       end
       let(:params) { { :env => 'production' } }
 
-      it { should include_class('puppet::agent') }
+      it { should contain_class('puppet::agent') }
 
       it { should contain_file('puppet_agent_sysconfig').with({
           'path'    => '/etc/default/puppet',
@@ -86,7 +86,7 @@ describe 'puppet::agent' do
       end
       let(:params) { { :env => 'production' } }
 
-      it { should include_class('puppet::agent') }
+      it { should contain_class('puppet::agent') }
 
       it { should contain_file('puppet_agent_sysconfig').with({
           'path'    => '/etc/default/puppet',
@@ -103,7 +103,7 @@ describe 'puppet::agent' do
       let(:facts) { { :osfamily => 'Solaris' } }
       let(:params) { { :env => 'production' } }
 
-      it { should include_class('puppet::agent') }
+      it { should contain_class('puppet::agent') }
 
       it { should_not contain_file('puppet_agent_sysconfig') }
     end
@@ -112,7 +112,7 @@ describe 'puppet::agent' do
       let(:facts) { { :osfamily => 'Suse' } }
       let(:params) { { :env => 'production' } }
 
-      it { should include_class('puppet::agent') }
+      it { should contain_class('puppet::agent') }
 
       it { should contain_file('puppet_agent_sysconfig').with({
           'path'    => '/etc/sysconfig/puppet',
@@ -131,7 +131,7 @@ describe 'puppet::agent' do
 
       it 'should fail' do
         expect {
-          should include_class('puppet::agent')
+          should contain_class('puppet::agent')
         }.to raise_error(Puppet::Error,/puppet::agent supports osfamilies Debian, RedHat, Solaris, and Suse. Detected osfamily is <invalid>./)
       end
     end
@@ -204,7 +204,7 @@ describe 'puppet::agent' do
         }
       end
 
-      it { should include_class('puppet::agent') }
+      it { should contain_class('puppet::agent') }
 
       it { should contain_cron('puppet_agent').with({
           'user' => 'root',

--- a/spec/classes/dashboard_maintenance_spec.rb
+++ b/spec/classes/dashboard_maintenance_spec.rb
@@ -12,7 +12,7 @@ describe 'puppet::dashboard::maintenance' do
         }
       end
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
 
       it { should contain_file('/var/local').with({
           'ensure' => 'directory',
@@ -31,7 +31,7 @@ describe 'puppet::dashboard::maintenance' do
         }
       end
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
 
       it { should contain_file('/var/local').with({
           'ensure' => 'directory',
@@ -51,7 +51,7 @@ describe 'puppet::dashboard::maintenance' do
         }
       end
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
 
       it { should contain_file('/foo/bar').with({
           'ensure' => 'directory',
@@ -72,7 +72,7 @@ describe 'puppet::dashboard::maintenance' do
 
       it do
         expect {
-          should include_class('puppet::dashboard::maintenance')
+          should contain_class('puppet::dashboard::maintenance')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -87,7 +87,7 @@ describe 'puppet::dashboard::maintenance' do
         }
       end
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
 
       it { should contain_cron('monthly_dashboard_database_optimization').with({
           'command'  => '/foo/bar',
@@ -109,7 +109,7 @@ describe 'puppet::dashboard::maintenance' do
         }
       end
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
 
       it { should contain_cron('purge_old_reports').with({
           'command'  => '/foo/bar',
@@ -127,7 +127,7 @@ describe 'puppet::dashboard::maintenance' do
                      :max_allowed_packet => 32,
                      :operatingsystemrelease => '6.4' } }
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
       it { should contain_cron('remove_old_reports_spool').with({
           'command'  => '/bin/find /usr/share/puppet-dashboard/spool -type f -name "*.yaml" -mtime +7 -exec /bin/rm -f {} \;',
           'ensure'   => 'present',
@@ -150,7 +150,7 @@ describe 'puppet::dashboard::maintenance' do
                      :max_allowed_packet => 32,
                      :operatingsystemrelease => '6.4' } }
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
       it { should contain_cron('remove_old_reports_spool').with({
           'ensure'   => 'present',
           'command'  => '/bin/find /tmp/foo -type f -name "*.yaml" -mtime +10 -exec /bin/rm -f {} \;',
@@ -168,7 +168,7 @@ describe 'puppet::dashboard::maintenance' do
                      :max_allowed_packet => 32,
                      :operatingsystemrelease => '6.4' } }
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
       it { should contain_cron('remove_old_reports_spool').with({
           'ensure'   => 'absent',
         })
@@ -187,7 +187,7 @@ describe 'puppet::dashboard::maintenance' do
 
       it do
         expect {
-          should include_class('puppet::dashboard::maintenance')
+          should contain_class('puppet::dashboard::maintenance')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -198,7 +198,7 @@ describe 'puppet::dashboard::maintenance' do
                      :max_allowed_packet     => 32,
                      :operatingsystemrelease => '6.4' } }
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
       it { should contain_cron('dump_dashboard_database').with({
           'command'  => 'cd ~puppet-dashboard && sudo -u puppet-dashboard /usr/bin/rake -f /usr/share/puppet-dashboard/Rakefile RAILS_ENV=production FILE=/var/local/dashboard-`date -I`.sql db:raw:dump >> /var/log/puppet/dashboard_maintenance.log 2>&1 && bzip2 -v9 /var/local/dashboard-`date -I`.sql >> /var/log/puppet/dashboard_maintenance.log 2>&1',
           'user'     => 'root',
@@ -214,7 +214,7 @@ describe 'puppet::dashboard::maintenance' do
                      :max_allowed_packet     => 32,
                      :operatingsystemrelease => '6.0.8' } }
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
       it { should contain_cron('dump_dashboard_database').with({
           'command'  => 'cd ~puppet-dashboard && sudo -u puppet /usr/bin/rake -f /usr/share/puppet-dashboard/Rakefile RAILS_ENV=production FILE=/var/local/dashboard-`date -I`.sql db:raw:dump >> /var/log/puppet/dashboard_maintenance.log 2>&1 && bzip2 -v9 /var/local/dashboard-`date -I`.sql >> /var/log/puppet/dashboard_maintenance.log 2>&1',
           'user'     => 'root',
@@ -231,7 +231,7 @@ describe 'puppet::dashboard::maintenance' do
                      :max_allowed_packet     => 32,
                      :operatingsystemrelease => '6.4' } }
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
       it { should contain_cron('dump_dashboard_database').with({
           'command'  => '/foo/bar',
           'user'     => 'root',
@@ -250,7 +250,7 @@ describe 'puppet::dashboard::maintenance' do
         }
       end
 
-      it { should include_class('puppet::dashboard::maintenance') }
+      it { should contain_class('puppet::dashboard::maintenance') }
 
       it { should contain_cron('purge_old_db_backups').with({
           'user'     => 'root',

--- a/spec/classes/dashboard_server_spec.rb
+++ b/spec/classes/dashboard_server_spec.rb
@@ -12,7 +12,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should_not contain_file('dashboard_workers_default') }
   end
@@ -27,7 +27,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_file('dashboard_workers_default').with({
         'ensure' => 'file',
@@ -54,7 +54,7 @@ describe 'puppet::dashboard::server' do
 
     it do
       expect {
-        should include_class('puppet::dashboard')
+        should contain_class('puppet::dashboard')
       }.to raise_error(Puppet::Error,/puppet::dashboard::server::dashboard_workers must be a digit. Detected value is <8invalid>./)
     end
 
@@ -80,7 +80,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_file('dashboard_htpasswd_path').with({
         'ensure' => 'file',
@@ -111,7 +111,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_file('dashboard_htpasswd_path').with({
         'ensure' => 'file',
@@ -143,7 +143,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_file('dashboard_htpasswd_path').with({
         'ensure' => 'file',
@@ -178,7 +178,7 @@ describe 'puppet::dashboard::server' do
 
     it do
       expect {
-        should include_class('puppet::dashboard')
+        should contain_class('puppet::dashboard')
       }.to raise_error(Puppet::Error)
     end
   end
@@ -198,7 +198,7 @@ describe 'puppet::dashboard::server' do
 
       it do
         expect {
-          should include_class('puppet::dashboard')
+          should contain_class('puppet::dashboard')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -217,7 +217,7 @@ describe 'puppet::dashboard::server' do
 
       it do
         expect {
-          should include_class('puppet::dashboard')
+          should contain_class('puppet::dashboard')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -236,7 +236,7 @@ describe 'puppet::dashboard::server' do
 
       it do
         expect {
-          should include_class('puppet::dashboard')
+          should contain_class('puppet::dashboard')
         }.to raise_error(Puppet::Error,/Security is <invalid> which does not match regex. Valid values are none and htpasswd./)
       end
     end
@@ -252,7 +252,7 @@ describe 'puppet::dashboard::server' do
         }
       end
 
-      it { should include_class('puppet::dashboard::server') }
+      it { should contain_class('puppet::dashboard::server') }
 
       it { should contain_file('dashboard_vhost').with_content(/^\s*ServerName puppet.example.com$/) }
     end
@@ -268,7 +268,7 @@ describe 'puppet::dashboard::server' do
         }
       end
 
-      it { should include_class('puppet::dashboard::server') }
+      it { should contain_class('puppet::dashboard::server') }
 
       it { should contain_file('dashboard_vhost') }
 
@@ -286,7 +286,7 @@ describe 'puppet::dashboard::server' do
         }
       end
 
-      it { should include_class('puppet::dashboard::server') }
+      it { should contain_class('puppet::dashboard::server') }
 
       it { should contain_file('dashboard_vhost').with_content(/(\s+|)AuthType(\s+)basic(\s*)/) }
     end
@@ -302,7 +302,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_file('database_config').with({
         'path'    => '/usr/share/puppet-dashboard/config/database.yml',
@@ -323,7 +323,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_file('database_config').with({
         'path'    => '/usr/share/puppet-dashboard/config/database.yml',
@@ -344,7 +344,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_file('database_config').with_content(/^\s*username: dashboard$/) }
   end
@@ -360,7 +360,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_file('dashboard_vhost').with({
         'ensure'  => 'file',
@@ -383,7 +383,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_file('dashboard_vhost').with({
         'ensure'  => 'file',
@@ -405,7 +405,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_mysql__db('dashboard').with({
         'user'     => 'dashboard',
@@ -425,7 +425,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_exec('migrate_dashboard_database').with({
         'command'     => 'rake RAILS_ENV=production db:migrate',
@@ -446,7 +446,7 @@ describe 'puppet::dashboard::server' do
       }
     end
 
-    it { should include_class('puppet::dashboard::server') }
+    it { should contain_class('puppet::dashboard::server') }
 
     it { should contain_service('puppet-dashboard-workers').with({
         'ensure'    => 'running',

--- a/spec/classes/dashboard_spec.rb
+++ b/spec/classes/dashboard_spec.rb
@@ -12,7 +12,7 @@ describe 'puppet::dashboard' do
         }
       end
 
-      it { should include_class('puppet::dashboard') }
+      it { should contain_class('puppet::dashboard') }
 
       it { should contain_package('puppet_dashboard').with({
           'ensure' => 'present',
@@ -30,7 +30,7 @@ describe 'puppet::dashboard' do
         }
       end
 
-      it { should include_class('puppet::dashboard') }
+      it { should contain_class('puppet::dashboard') }
 
       it { should contain_file('external_node_script').with({
           'ensure' => 'file',
@@ -51,7 +51,7 @@ describe 'puppet::dashboard' do
         }
       end
 
-      it { should include_class('puppet::dashboard') }
+      it { should contain_class('puppet::dashboard') }
 
       it { should contain_file('external_node_script').with({
           'ensure' => 'file',
@@ -73,7 +73,7 @@ describe 'puppet::dashboard' do
         }
       end
 
-      it { should include_class('puppet::dashboard') }
+      it { should contain_class('puppet::dashboard') }
 
       it { should contain_file('external_node_script').with({
           'ensure' => 'file',
@@ -97,7 +97,7 @@ describe 'puppet::dashboard' do
 
       it 'should fail' do
         expect {
-          should include_class('puppet::dashboard')
+          should contain_class('puppet::dashboard')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -111,7 +111,7 @@ describe 'puppet::dashboard' do
         }
       end
 
-      it { should include_class('puppet::dashboard') }
+      it { should contain_class('puppet::dashboard') }
 
       it { should contain_file('dashboard_sysconfig').with({
           'ensure' => 'file',
@@ -134,7 +134,7 @@ describe 'puppet::dashboard' do
         }
       end
 
-      it { should include_class('puppet::dashboard') }
+      it { should contain_class('puppet::dashboard') }
 
       it { should contain_file('dashboard_sysconfig').with({
           'ensure' => 'file',
@@ -165,7 +165,7 @@ describe 'puppet::dashboard' do
 
       it 'should fail' do
         expect {
-          should include_class('puppet::dashboard')
+          should contain_class('puppet::dashboard')
         }.to raise_error(Puppet::Error,/puppet::dashboard supports osfamilies Debian and RedHat. Detected osfamily is <invalid>./)
       end
     end
@@ -182,7 +182,7 @@ describe 'puppet::dashboard' do
 
       it 'should fail' do
         expect {
-          should include_class('puppet::dashboard')
+          should contain_class('puppet::dashboard')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -196,7 +196,7 @@ describe 'puppet::dashboard' do
         }
       end
 
-      it { should include_class('puppet::dashboard') }
+      it { should contain_class('puppet::dashboard') }
 
       it { should contain_service('puppet-dashboard').with({
           'ensure'    => 'stopped',
@@ -214,7 +214,7 @@ describe 'puppet::dashboard' do
         }
       end
 
-      it { should include_class('puppet::dashboard') }
+      it { should contain_class('puppet::dashboard') }
 
       it { should contain_service('puppet-dashboard-workers').with({
           'ensure'    => 'stopped',

--- a/spec/classes/lint_spec.rb
+++ b/spec/classes/lint_spec.rb
@@ -7,7 +7,7 @@ describe 'puppet::lint' do
     context 'Puppet Lint package' do
       let(:params) { {:provider => 'gem' } }
 
-      it { should include_class('puppet::lint') }
+      it { should contain_class('puppet::lint') }
 
       it { should contain_package('puppet-lint').with({
           'provider' => 'gem',
@@ -22,7 +22,7 @@ describe 'puppet::lint' do
         }
       end
 
-      it { should include_class('puppet::lint') }
+      it { should contain_class('puppet::lint') }
 
       it { should contain_file('/root/.puppet-lint.rc').with({
           'owner' => 'root',

--- a/spec/classes/master_maintenance_spec.rb
+++ b/spec/classes/master_maintenance_spec.rb
@@ -5,7 +5,7 @@ describe 'puppet::master::maintenance' do
   describe 'class puppet::master::maintenance' do
 
     context 'Puppetmaster maintenance cron' do
-      it { should include_class('puppet::master::maintenance') }
+      it { should contain_class('puppet::master::maintenance') }
       it { should contain_cron('filebucket_cleanup').with({
           'user'    => 'root',
           'hour'    => '0',

--- a/spec/classes/master_spec.rb
+++ b/spec/classes/master_spec.rb
@@ -11,7 +11,7 @@ describe 'puppet::master' do
         }
       end
 
-      it { should include_class('puppet::master') }
+      it { should contain_class('puppet::master') }
 
       it { should contain_file('/etc/puppet/auth.conf').with({
           'owner' => 'root',
@@ -27,7 +27,7 @@ describe 'puppet::master' do
         }
       end
 
-      it { should include_class('puppet::master') }
+      it { should contain_class('puppet::master') }
 
       it { should contain_file('/etc/puppet/fileserver.conf').with({
           'owner' => 'root',
@@ -43,7 +43,7 @@ describe 'puppet::master' do
         }
       end
 
-      it { should include_class('puppet::master') }
+      it { should contain_class('puppet::master') }
 
       it { should contain_file('puppetmaster_sysconfig').with_content(/^#PUPPETMASTER_LOG=syslog$/) }
     end
@@ -56,7 +56,7 @@ describe 'puppet::master' do
         }
       end
 
-      it { should include_class('puppet::master') }
+      it { should contain_class('puppet::master') }
 
       it { should contain_file('puppetmaster_sysconfig').with_content(/^START=no$/) }
       it { should contain_file('puppetmaster_sysconfig').with_content(/^DAEMON_OPTS=""$/) }
@@ -73,7 +73,7 @@ describe 'puppet::master' do
 
       it 'should fail' do
         expect {
-          should include_class('puppet::master')
+          should contain_class('puppet::master')
         }.to raise_error(Puppet::Error,/puppet::master supports osfamilies Debian and RedHat. Detected osfamily is <invalid>./)
       end
     end
@@ -89,7 +89,7 @@ describe 'puppet::master' do
 
       it 'should fail' do
         expect {
-          should include_class('puppet::master')
+          should contain_class('puppet::master')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -103,7 +103,7 @@ describe 'puppet::master' do
         }
       end
 
-      it { should include_class('puppet::master') }
+      it { should contain_class('puppet::master') }
 
       it { should contain_file('/foo/bar').with({
           'ensure' => 'directory',
@@ -120,7 +120,7 @@ describe 'puppet::master' do
         }
       end
 
-      it { should include_class('puppet::master') }
+      it { should contain_class('puppet::master') }
 
       it { should contain_file('/foo/bar/config.ru').with({
           'owner'   => 'puppet',
@@ -138,7 +138,7 @@ describe 'puppet::master' do
         }
       end
 
-      it { should include_class('puppet::master') }
+      it { should contain_class('puppet::master') }
 
       it { should contain_file('puppetmaster_vhost').with({
           'ensure'  => 'file',
@@ -158,7 +158,7 @@ describe 'puppet::master' do
         }
       end
 
-      it { should include_class('puppet::master') }
+      it { should contain_class('puppet::master') }
 
       it { should contain_file('puppetmaster_vhost').with({
           'ensure'  => 'file',
@@ -179,7 +179,7 @@ describe 'puppet::master' do
         }
       end
 
-      it { should include_class('puppet::master') }
+      it { should contain_class('puppet::master') }
 
       it { should contain_file('puppetmaster_vhost').with({
           'ensure'  => 'file',
@@ -202,7 +202,7 @@ describe 'puppet::master' do
 
       it 'should fail' do
         expect {
-          should include_class('puppet::master')
+          should contain_class('puppet::master')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -215,7 +215,7 @@ describe 'puppet::master' do
         }
       end
 
-      it { should include_class('puppet::master') }
+      it { should contain_class('puppet::master') }
 
       it { should contain_file('puppetmaster_vhost').with_content(/^\s*<Directory \/usr\/share\/puppet\/rack\/puppetmasterd\/>$/) }
     end


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
