### PR TITLE
Fix for ubuntu 12.04 server compatibility

### DIFF
--- a/templates/puppetmaster_sysconfig.erb
+++ b/templates/puppetmaster_sysconfig.erb
@@ -14,3 +14,8 @@
 
 # You may specify other parameters to the puppetmaster here
 #PUPPETMASTER_EXTRA_OPTS=--no-ca
+
+# Enable puppet agent service?
+# Setting this to "yes" allows the puppet agent service to run.
+# Setting this to "no" keeps the puppet agent service from running.
+START=yes


### PR DESCRIPTION
If you don't have `START=yes` then you get this error: `puppet not configured to start, please edit /etc/default/puppet to enable` each time you do `service puppet start`