### PR TITLE
Remove puppet_agent_once_at_boot even when run_method differ from cron

### DIFF
--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -308,7 +308,10 @@ describe 'puppet::agent' do
         })
       }
 
-      it { should_not contain_cron('puppet_agent_once_at_boot') }
+      it { should_not contain_cron('puppet_agent_once_at_boot').with({
+          'ensure' => 'present',
+        })
+      }
 
       it { should contain_service('puppet_agent_daemon').with({
           'enable' => false,
@@ -331,7 +334,10 @@ describe 'puppet::agent' do
         })
       }
 
-      it { should_not contain_cron('puppet_agent_once_at_boot') }
+      it { should_not contain_cron('puppet_agent_once_at_boot').with({
+          'ensure' => 'present',
+        })
+      }
 
       it { should contain_service('puppet_agent_daemon').with({
           'enable' => true,


### PR DESCRIPTION
Cronjob not removed if set for example

puppet::agent::run_method: 'disable'
puppet::agent::run_at_boot: 'false'
