### PR TITLE
Fixup malformed dependency in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -76,7 +76,7 @@
   ],
   "description": "Manages Puppet, including Master, Agent, Dashboard and maintenance tasks.",
   "dependencies": [
-    {"name":"ghoneycutt/common","version_requirement":">= v1.0.3"},
+    {"name":"ghoneycutt/common","version_requirement":">= 1.0.3"},
     {"name":"leinaddm/htpasswd","version_requirement":">= 0.0.1"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0"},
     {"name":"puppetlabs/mysql","version_requirement":">= 2.0.0"},


### PR DESCRIPTION
Fixup malformed dependency in metadata.json that triggers backtrace in librarian-puppet
