### PR TITLE
Add etckeeper hooks

### DIFF
--- a/files/etckeeper-commit-post
+++ b/files/etckeeper-commit-post
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+which etckeeper > /dev/null 2>&1 || exit 0
+
+etckeeper commit "committing changes in /etc after puppet catalog run"
+
+# Failure of etckeeper should not be fatal.
+exit 0

--- a/files/etckeeper-commit-pre
+++ b/files/etckeeper-commit-pre
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+which etckeeper > /dev/null 2>&1 || exit 0
+
+etckeeper commit "saving uncommitted changes in /etc prior to puppet catalog run"
+
+# Failure of etckeeper should not be fatal.
+exit 0

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -177,6 +177,22 @@ class puppet::agent (
     mode    => $config_mode,
   }
 
+  file { 'etckeeper_pre':
+    path   => '/etc/puppet/etckeeper-commit-pre',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/puppet/etckeeper-commit-pre'
+  }
+
+  file { 'etckeeper_post':
+    path   => '/etc/puppet/etckeeper-commit-post',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+    source => 'puppet:///modules/puppet/etckeeper-commit-post'
+  }
+
   if $default_agent_sysconfig_ensure =~ /(present)|(file)/ {
     file { 'puppet_agent_sysconfig':
       ensure  => $agent_sysconfig_ensure_real,

--- a/templates/puppetagent.conf.erb
+++ b/templates/puppetagent.conf.erb
@@ -22,6 +22,10 @@
     # were introduced in Facter v2
     stringify_facts = <%= @stringify_facts_bool %>
 
+    # Use etckeeper if it is enabled
+    prerun_command=/etc/puppet/etckeeper-commit-pre
+    postrun_command=/etc/puppet/etckeeper-commit-post
+
 [agent]
     # The file in which puppetd stores a list of the classes
     # associated with the retrieved configuratiion.  Can be loaded in


### PR DESCRIPTION
Puppet package, at least on ubuntu, creates nice pre and post-commit hooks which help people who have etckeeper installed and don't yet live in the automatic-server-deployment utopia.
