### PR TITLE
Add parameters for http_proxy and http_proxy_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ The puppet CA server the client should use
 
 - *Default*: UNSET
 
+http_proxy_host
+---------------
+The http-proxy the client should use
+
+- *Default*: UNSET
+
+http_proxy_port
+----------------
+The http-proxy port the client should use
+
+- *Default*: UNSET
+
 is_puppet_master
 ----------------
 Whether the machine is a puppet master or not.

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -15,6 +15,8 @@ class puppet::agent (
   $puppet_server                = 'puppet',
   $puppet_masterport            = 'UNSET',
   $puppet_ca_server             = 'UNSET',
+  $http_proxy_host              = 'UNSET',
+  $http_proxy_port              = 'UNSET',
   $is_puppet_master             = false,
   $run_method                   = 'service',
   $run_interval                 = '30',
@@ -74,6 +76,14 @@ class puppet::agent (
     $etckeeper_hooks_bool = $etckeeper_hooks
   }
   validate_bool($etckeeper_hooks_bool)
+
+  if $http_proxy_host != 'UNSET' and (is_domain_name($http_proxy_host) == false and is_ip_address($http_proxy_host) == false){
+    fail("puppet::agent::http_proxy_host is set to <${http_proxy_host}>. It should be a fqdn or an ip-address.")
+  }
+
+  if $http_proxy_port != 'UNSET' and is_integer($http_proxy_port) == false {
+    fail("puppet::agent::http_proxy_port is set to <${http_proxy_port}>. It should be an Integer.")
+  }
 
   case $::osfamily {
     'Debian': {

--- a/templates/puppetagent.conf.erb
+++ b/templates/puppetagent.conf.erb
@@ -43,6 +43,8 @@
     server = <%= @puppet_server %>
 <% if @puppet_masterport != 'UNSET' %>    masterport = <%= @puppet_masterport %><% end %>
 <% if @puppet_ca_server != 'UNSET' %>    ca_server = <%= @puppet_ca_server %><% end %>
+<% if @http_proxy_host != 'UNSET' %>    http_proxy_host = <%= @http_proxy_host %><% end %>
+<% if @http_proxy_port != 'UNSET' %>    http_proxy_port = <%= @http_proxy_port %><% end %>
     report = true
     graph = true
     pluginsync = true


### PR DESCRIPTION
Allows setting http_proxy_host and http_proxy_port in agent's puppet.conf
