### PR TITLE
Support disabling cronjobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,10 @@ Whether to manage the firewall settings on the client
 
 ### Parameters ###
 
+clientbucket_cleanup_ensure
+---------------------------
+String for ensure parameter for filebucket_cleanup cron job
+
 clientbucket_path
 -----------------
 Path to where the clientbucket files are stored.
@@ -694,6 +698,10 @@ filebucket_cleanup_minute
 Minute at which to run the filebucket cleanup.
 
 - *Default*: 0
+
+reportdir_purge_ensure
+---------------------------
+String for ensure parameter for purge_old_puppet_reports cron job
 
 reportdir
 ---------

--- a/manifests/master/maintenance.pp
+++ b/manifests/master/maintenance.pp
@@ -1,21 +1,27 @@
 # == Class: puppet::master::maintenance
 #
 class puppet::master::maintenance (
-  $clientbucket_path          = '/var/lib/puppet/clientbucket/',
-  $clientbucket_days_to_keep  = '30',
-  $filebucket_cleanup_command = '/usr/bin/find /var/lib/puppet/clientbucket/ -type f -mtime +30 -exec /bin/rm -fr {} \;',
-  $filebucket_cleanup_user    = 'root',
-  $filebucket_cleanup_hour    = '0',
-  $filebucket_cleanup_minute  = '0',
-  $reportdir                   = $::puppet_reportdir,
-  $reportdir_days_to_keep      = '30',
-  $reportdir_purge_command     = '/usr/bin/find -L /var/lib/puppet/reports -type f -mtime +30 -exec /bin/rm -fr {} \;',
-  $reportdir_purge_user        = 'root',
-  $reportdir_purge_hour        = '0',
-  $reportdir_purge_minute      = '15',
+  $clientbucket_cleanup_ensure  = 'present',
+  $clientbucket_path            = '/var/lib/puppet/clientbucket/',
+  $clientbucket_days_to_keep    = '30',
+  $filebucket_cleanup_command   = '/usr/bin/find /var/lib/puppet/clientbucket/ -type f -mtime +30 -exec /bin/rm -fr {} \;',
+  $filebucket_cleanup_user      = 'root',
+  $filebucket_cleanup_hour      = '0',
+  $filebucket_cleanup_minute    = '0',
+  $reportdir_purge_ensure       = 'present',
+  $reportdir                    = $::puppet_reportdir,
+  $reportdir_days_to_keep       = '30',
+  $reportdir_purge_command      = '/usr/bin/find -L /var/lib/puppet/reports -type f -mtime +30 -exec /bin/rm -fr {} \;',
+  $reportdir_purge_user         = 'root',
+  $reportdir_purge_hour         = '0',
+  $reportdir_purge_minute       = '15',
 ) {
 
   validate_absolute_path($reportdir)
+
+  validate_re($clientbucket_cleanup_ensure, '^(present|absent)$', "clientbucket_cleanup_ensure must be 'present' or 'absent'. Detected value is <${clientbucket_cleanup_ensure}>")
+
+  validate_re($reportdir_purge_ensure, '^(present|absent)$', "reportdir_purge_ensure must be 'present' or 'absent'. Detected value is <${reportdir_purge_ensure}>")
 
   # if not using the defaults, then construct the command with variables, else
   # use the default command
@@ -26,7 +32,7 @@ class puppet::master::maintenance (
   }
 
   cron { 'filebucket_cleanup':
-    ensure  => present,
+    ensure  => $clientbucket_cleanup_ensure,
     command => $my_filebucket_cleanup_command,
     user    => $filebucket_cleanup_user,
     hour    => $filebucket_cleanup_hour,
@@ -44,10 +50,11 @@ class puppet::master::maintenance (
   }
 
   cron { 'purge_old_puppet_reports':
-    ensure  => present,
+    ensure  => $reportdir_purge_ensure,
     command => $my_reportdir_purge_command,
     user    => $reportdir_purge_user,
     hour    => $reportdir_purge_hour,
     minute  => $reportdir_purge_minute,
   }
+
 }

--- a/spec/classes/master_maintenance_spec.rb
+++ b/spec/classes/master_maintenance_spec.rb
@@ -16,6 +16,29 @@ describe 'puppet::master::maintenance' do
         })
       }
     end
+
+    context 'with reportdir_purge_ensure set to invalid value' do
+      let(:facts) { { :puppet_reportdir => '/var/lib/puppet/reports', } }
+      let(:params) { { :reportdir_purge_ensure => 'installed', } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('puppet::master::maintenance')
+        }.to raise_error(Puppet::Error,/^reportdir_purge_ensure must be 'present' or 'absent'. Detected value is <installed>/)
+      end
+    end
+
+    context 'with clientbucket_cleanup_ensure set to invalid value' do
+      let(:facts) { { :puppet_reportdir => '/var/lib/puppet/reports', } }
+      let(:params) { { :clientbucket_cleanup_ensure => 'installed', } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('puppet::master::maintenance')
+        }.to raise_error(Puppet::Error,/^clientbucket_cleanup_ensure must be 'present' or 'absent'. Detected value is <installed>/)
+      end
+    end
+
   end
 
   describe 'clientbucket cleanup' do
@@ -110,6 +133,23 @@ describe 'puppet::master::maintenance' do
         })
       }
     end
+
+    context 'with clientbucket_cleanup_ensure set to absent' do
+      let(:facts) do
+        { :puppet_reportdir => '/var/lib/puppet/reports', }
+      end
+      let(:params) do
+        { :clientbucket_cleanup_ensure => 'absent', }
+      end
+
+      it { should contain_class('puppet::master::maintenance') }
+
+      it { should contain_cron('filebucket_cleanup').with({
+          'ensure'  => 'absent'
+        })
+      }
+    end
+
   end
 
   describe 'purge reportdir' do
@@ -263,5 +303,23 @@ describe 'puppet::master::maintenance' do
         })
       }
     end
+
+    context 'with purge_old_puppet_reports set to absent' do
+      let(:facts) do
+        { :puppet_reportdir => '/var/lib/puppet/reports', }
+      end
+      let(:params) do
+        { :reportdir_purge_ensure => 'absent', }
+      end
+
+      it { should contain_class('puppet::master::maintenance') }
+
+      it { should contain_cron('purge_old_puppet_reports').with({
+          'ensure'  => 'absent'
+        })
+      }
+
+    end
+
   end
 end


### PR DESCRIPTION
Previously commit was a preparation for this commit. However felt that it was better to commit it as an standalone commit.

Since all puppet masters are currently running reportdir purge cron job at the same a mail is sometimes sent to the root mailbox that rsync was unable to delete a file because it has already been deleted.
We solved this by setting puppet::master::maintenance::reportdir_purge_command to something else like an echo into /dev/null. However this feels like a better solution.

Thank you for solving the issues in my previous pull request.