### PR TITLE
make hardcoded commands really flexible

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
       ref: '0.2.1'
     stdlib:
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '3.2.0'
+      ref: '4.6.0'
     mysql:
       repo: 'git://github.com/puppetlabs/puppetlabs-mysql.git'
       ref: '2.0.1-rc1'

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,8 @@ end
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
+
+# rspec must be v2 for ruby 1.8.7
+if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'rspec', '~> 2.0'
+end

--- a/README.md
+++ b/README.md
@@ -446,8 +446,11 @@ How many days to keep the reports.
 purge_old_reports_command
 -------------------------
 Which command to run to purge old reports.
+Defaults to: '/usr/bin/rake -f /usr/share/puppet-dashboard/Rakefile RAILS_ENV=production reports:prune upto=${reports_days_to_keep} unit=day >> /var/log/puppet/dashboard_maintenance.log'
+If using a specific command here, please keep in mind you need to align it with $reports_days_to_keep yourself.
 
-- *Default*: /usr/bin/rake -f /usr/share/puppet-dashboard/Rakefile RAILS_ENV=production reports:prune upto=30 unit=day >> /var/log/puppet/dashboard_maintenance.log
+- *Default*: 'USE_DEFAULTS'
+
 
 purge_old_reports_user
 ----------------------
@@ -510,8 +513,10 @@ The directory to use for dumps.
 dump_database_command
 ---------------------
 The command to run to dump the database.
+Defaults to: 'cd ~puppet-dashboard && sudo -u ${puppet::dashboard::dashboard_user_real} /usr/bin/rake -f /usr/share/puppet-dashboard/Rakefile RAILS_ENV=production FILE=${dump_dir}/dashboard-`date -I`.sql db:raw:dump >> /var/log/puppet/dashboard_maintenance.log 2>&1 && bzip2 -v9 ${dump_dir}/dashboard-`date -I`.sql >> /var/log/puppet/dashboard_maintenance.log 2>&1'
+If using a specific command here, please keep in mind you need to align it with $puppet::dashboard::dashboard_user & $dump_dir yourself.
 
-- *Default*: sudo -u puppet-dashboard /usr/bin/rake -f /usr/share/puppet-dashboard/Rakefile RAILS_ENV=production FILE=/var/local/dashboard-`date -I`.sql db:raw:dump >> /var/log/puppet/dashboard_maintenance.log && bzip2 -v9 /var/local/dashboard-`date -I`.sql >> /var/log/puppet/dashboard_maintenance.log
+- *Default*: 'USE_DEFAULTS'
 
 dump_database_user
 ------------------

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -590,7 +590,7 @@ describe 'puppet::agent' do
       it 'should fail' do
         expect {
           should contain_class('puppet::agent')
-        }.to raise_error(Puppet::Error,/^undefined method `to_i'/)
+        }.to raise_error(Puppet::Error,/^puppet::agent::puppet_masterport is set to <invalidtype>. It should be an integer./)
       end
     end
   end
@@ -696,7 +696,7 @@ describe 'puppet::agent' do
       it 'should fail' do
         expect {
           should contain_class('puppet::agent')
-        }.to raise_error(Puppet::Error,/chomp/)
+        }.to raise_error(Puppet::Error,/^puppet::agent::http_proxy_host is set to <invalidtype>. It should be a fqdn or an ip-address./)
       end
     end
   end
@@ -723,7 +723,7 @@ describe 'puppet::agent' do
       it 'should fail' do
         expect {
           should contain_class('puppet::agent')
-        }.to raise_error(Puppet::Error,/^undefined method `to_i'/)
+        }.to raise_error(Puppet::Error,/^puppet::agent::http_proxy_port is set to <invalidtype>. It should be an Integer./)
       end
     end
     context 'set to an invalid value' do


### PR DESCRIPTION
For an easier read I left the commits in singletons, each one will pass the spec tests. Will be rebased later.

I was able to remove the unfunctional junctions that were preventing to use specific commands for ```$purge_old_reports_command``` & ```$dump_database_command``` without breaking anything :)
Includes upgrade to stdlib 4.2.0 for better error messages and functionality upgrades.

This PR is a preview, real life test if this fix my issue https://github.com/ghoneycutt/puppet-module-puppet/issues/101 will be done tomorrow.
