### PR TITLE
parameterize ssldir in puppet agent's config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,8 @@ end
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
+
+# rspec must be v2 for ruby 1.8.7
+if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'rspec', '~> 2.0'
+end

--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ The name the puppet agent daemon should run as.
 
 - *Default*: puppet
 
+ssldir
+------
+String for ssldir in puppet agent's config.
+
+- *Default*: '$vardir/ssl'
+
 stringify_facts
 ---------------
 Boolean to set the value of stringify_facts main section of the puppet agent's config. This must be set to true to use structured facts.

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -29,6 +29,7 @@ class puppet::agent (
   $agent_sysconfig              = 'USE_DEFAULTS',
   $agent_sysconfig_ensure       = 'USE_DEFAULTS',
   $daemon_name                  = 'puppet',
+  $ssldir                       = '$vardir/ssl',
   $stringify_facts              = true,
   $etckeeper_hooks              = false,
 ) {
@@ -61,6 +62,11 @@ class puppet::agent (
 
   if $puppet_masterport != 'UNSET' and is_integer($puppet_masterport) == false {
     fail("puppet::agent::puppet_masterport is set to <${puppet_masterport}>. It should be an integer.")
+  }
+
+  # ssldir must be a string and contain a value, else fail
+  if is_string($ssldir) == false or $ssldir == '' {
+    fail('puppet::agent::ssldir must be set as string')
   }
 
   if type($stringify_facts) == 'string' {

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -191,6 +191,39 @@ describe 'puppet::agent' do
     end
   end
 
+  let(:facts) { { :osfamily => 'RedHat' } }
+  describe 'with ssldir' do
+    ['$vardir/ssl-test','/var/lib/puppet/ssl-test'].each do |value|
+      context "set to valid #{value} (as #{value.class})" do
+        let(:params) do
+          {
+            :ssldir => value,
+            :env    => 'production',
+          }
+        end
+
+        it { should contain_file('puppet_config').with_content(/^\s*ssldir = #{Regexp.escape(value)}$/) }
+      end
+    end
+
+    ['',242,2.42,['array'],a = { 'ha' => 'sh' }].each do |value|
+      context "set to invalid #{value} (as #{value.class})" do
+        let(:params) do
+          {
+            :ssldir => value,
+            :env    => 'production',
+          }
+        end
+
+        it 'should fail' do
+          expect {
+            should contain_class('puppet::agent')
+          }.to raise_error(Puppet::Error,/^puppet::agent::ssldir must be set as string/)
+        end
+      end
+    end
+  end
+
   describe 'with stringify_facts' do
     ['true',true].each do |value|
       context "set to #{value}" do

--- a/templates/puppetagent.conf.erb
+++ b/templates/puppetagent.conf.erb
@@ -12,7 +12,7 @@
 
     # Where SSL certificates are kept.
     # The default value is '$confdir/ssl'.
-    ssldir = $vardir/ssl
+    ssldir = <%= @ssldir %>
 
     archive_files = true
     archive_file_server = <%= @puppet_server %>


### PR DESCRIPTION
This patch parameterizes the ssldir setting in puppet agent's config.

Our puppet testing clients are registered to multiple Puppetmasters. With this patch it is possible to store the SSL certificates for each Puppetmasters cluster in a different path, makes switching Puppetmasters much more convenient.
