### PR TITLE
parameterize ssldir in puppet agent's config

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ The name the puppet agent daemon should run as.
 
 - *Default*: puppet
 
+ssldir
+------
+String with absolute path for ssldir in puppet agent's config. Using the default will set it to: '$vardir/ssl'
+
+- *Default*: 'USE_DEFAULTS'
+
 stringify_facts
 ---------------
 Boolean to set the value of stringify_facts main section of the puppet agent's config. This must be set to true to use structured facts.

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -29,6 +29,7 @@ class puppet::agent (
   $agent_sysconfig              = 'USE_DEFAULTS',
   $agent_sysconfig_ensure       = 'USE_DEFAULTS',
   $daemon_name                  = 'puppet',
+  $ssldir                       = 'USE_DEFAULTS',
   $stringify_facts              = true,
   $etckeeper_hooks              = false,
 ) {
@@ -61,6 +62,13 @@ class puppet::agent (
 
   if $puppet_masterport != 'UNSET' and is_integer($puppet_masterport) == false {
     fail("puppet::agent::puppet_masterport is set to <${puppet_masterport}>. It should be an integer.")
+  }
+
+  if $ssldir == 'USE_DEFAULTS' {
+    $ssldir_real = '$vardir/ssl'
+  } else {
+    validate_absolute_path($ssldir)
+    $ssldir_real = $ssldir
   }
 
   if is_string($stringify_facts) {

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -191,6 +191,39 @@ describe 'puppet::agent' do
     end
   end
 
+  let(:facts) { { :osfamily => 'RedHat' } }
+  describe 'with ssldir' do
+    ['/var/lib/puppet/ssl-test','/srv/puppet/ssl'].each do |value|
+      context "set to valid #{value} (as #{value.class})" do
+        let(:params) do
+          {
+            :ssldir => value,
+            :env    => 'production',
+          }
+        end
+
+        it { should contain_file('puppet_config').with_content(/^\s*ssldir = #{Regexp.escape(value)}$/) }
+      end
+    end
+
+    ['../../relative/path','',242,2.42,['array'],a={'ha'=>'sh'},true,nil].each do |value|
+      context "set to invalid #{value} (as #{value.class})" do
+        let(:params) do
+          {
+            :ssldir => value,
+            :env    => 'production',
+          }
+        end
+
+        it 'should fail' do
+          expect {
+            should contain_class('puppet::agent')
+          }.to raise_error(Puppet::Error,/is not an absolute path/)
+        end
+      end
+    end
+  end
+
   describe 'with stringify_facts' do
     ['true',true].each do |value|
       context "set to #{value}" do

--- a/templates/puppetagent.conf.erb
+++ b/templates/puppetagent.conf.erb
@@ -12,7 +12,7 @@
 
     # Where SSL certificates are kept.
     # The default value is '$confdir/ssl'.
-    ssldir = $vardir/ssl
+    ssldir = <%= @ssldir_real %>
 
     archive_files = true
     archive_file_server = <%= @puppet_server %>


### PR DESCRIPTION
successor of https://github.com/ghoneycutt/puppet-module-puppet/pull/103
- rebased against master
- adds validate_absolute_path()
