### PR TITLE
Add parameter for configuring environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ The name of the puppet CA server.
 - *Default*: 'puppet'
 
 ---
+#### env (type: Optional[String])
+Environment to configure in puppet.conf. If not specified, the environment
+of the current puppet run will be configured in puppet.conf.
+
+- *Default*: undef
+
+---
 #### graph (type: Variant[Enum['true', 'false'], Boolean])
 Value of the graph option in puppet.conf.
 

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ The name of the puppet CA server.
 
 ---
 #### env (type: Optional[String])
-Environment to configure in puppet.conf. If not specified, the environment
-of the current puppet run will be configured in puppet.conf.
+Environment to configure in puppet.conf, defaults to the environment
+of the current puppet run.
 
-- *Default*: undef
+- *Default*: $environment
 
 ---
 #### graph (type: Variant[Enum['true', 'false'], Boolean])

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@ class puppet (
   String                                  $config_path = '/etc/puppetlabs/puppet/puppet.conf',
   String                                  $server = 'puppet',
   String                                  $ca_server = 'puppet',
-  Optional[String]                        $env = undef,
+  Optional[String]                        $env = $environment,
   Variant[Enum['true', 'false'], Boolean] $graph = false, #lint:ignore:quoted_booleans
   Variant[Enum['true', 'false'], Boolean] $archive_files = false, #lint:ignore:quoted_booleans
   String                                  $archive_file_server = 'puppet',
@@ -81,12 +81,6 @@ class puppet (
     special => 'reboot',
   }
 
-  if $env != undef {
-    $environment_real = $env
-  } else {
-    $environment_real = $environment
-  }
-
   $ini_defaults = {
     ensure  => 'present',
     path    => $::puppet::config_path,
@@ -98,7 +92,7 @@ class puppet (
     'server'              => { setting => 'server', value => $server,},
     'ca_server'           => { setting => 'ca_server', value => $ca_server,},
     'certname'            => { setting => 'certname', value => $certname,},
-    'environment'         => { setting => 'environment', value => $environment_real,},
+    'environment'         => { setting => 'environment', value => $env,},
     'trusted_node_data'   => { setting => 'trusted_node_data', value => true,},
     'graph'               => { setting => 'graph', value => $graph,},
     'archive_files'       => { setting => 'archive_files', value => $archive_files,},

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class puppet (
   String                                  $config_path = '/etc/puppetlabs/puppet/puppet.conf',
   String                                  $server = 'puppet',
   String                                  $ca_server = 'puppet',
+  Optional[String]                        $env = undef,
   Variant[Enum['true', 'false'], Boolean] $graph = false, #lint:ignore:quoted_booleans
   Variant[Enum['true', 'false'], Boolean] $archive_files = false, #lint:ignore:quoted_booleans
   String                                  $archive_file_server = 'puppet',
@@ -80,6 +81,12 @@ class puppet (
     special => 'reboot',
   }
 
+  if $env != undef {
+    $environment_real = $env
+  } else {
+    $environment_real = $environment
+  }
+
   $ini_defaults = {
     ensure  => 'present',
     path    => $::puppet::config_path,
@@ -91,7 +98,7 @@ class puppet (
     'server'              => { setting => 'server', value => $server,},
     'ca_server'           => { setting => 'ca_server', value => $ca_server,},
     'certname'            => { setting => 'certname', value => $certname,},
-    'environment'         => { setting => 'environment', value => $environment,},
+    'environment'         => { setting => 'environment', value => $environment_real,},
     'trusted_node_data'   => { setting => 'trusted_node_data', value => true,},
     'graph'               => { setting => 'graph', value => $graph,},
     'archive_files'       => { setting => 'archive_files', value => $archive_files,},

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -210,6 +210,34 @@ describe 'puppet' do
     end
   end
 
+  describe 'with env specified' do
+    let(:params) { { :env => 'myenv' } }
+
+    it do
+      should contain_ini_setting('environment').with({
+        :ensure  => 'present',
+        :setting => 'environment',
+        :value   => 'myenv',
+        :path    => '/etc/puppetlabs/puppet/puppet.conf',
+        :section => 'main',
+        :require => 'File[puppet_config]',
+      })
+    end
+  end
+
+  describe 'without env specified' do
+    it do
+      should contain_ini_setting('environment').with({
+        :ensure  => 'present',
+        :setting => 'environment',
+        :value   => 'rp_env',
+        :path    => '/etc/puppetlabs/puppet/puppet.conf',
+        :section => 'main',
+        :require => 'File[puppet_config]',
+      })
+    end
+  end
+
   describe 'with server specified' do
     let(:params) { { :server => 'foo' } }
 


### PR DESCRIPTION
If not specified, the old module behavior is retained, i.e. configure
the environment of the current puppet run into puppet.conf.
This might not always be desirable, e.g. when manually running puppet
towards a possibly temporary test environment.
The env setting allows for statically configuring the environment to
use, e.g. production as the old puppet::agent class did.