### PR TITLE
Move dns_alt_names from puppet::server to puppet class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Value of the graph option in puppet.conf.
 - *Default*: false
 
 ---
+#### dns_alt_names (type: Optional[String])
+Value of the dns_alt_names option in puppet.conf.
+
+- *Default*: undef
+
+---
 #### agent_sysconfig_path (type: String)
 The absolute path to the puppet agent sysconfig file.
 
@@ -185,11 +191,5 @@ by the unit 'm' for MB or 'g' for GB.
 The absolute path to an ENC. If this is set, it will be the value for the
 external_nodes option in puppet.conf and the node_terminus option will
 be set to 'exec'.
-
-- *Default*: undef
-
----
-#### dns_alt_names (type: Optional[String])
-Value of the dns_alt_names option in puppet.conf.
 
 - *Default*: undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class puppet (
   String                                  $server = 'puppet',
   String                                  $ca_server = 'puppet',
   String                                  $env = $environment,
+  Optional[String]                        $dns_alt_names = undef,
   Variant[Enum['true', 'false'], Boolean] $graph = false, #lint:ignore:quoted_booleans
   String                                  $agent_sysconfig_path = '/etc/sysconfig/puppet',
 ) {
@@ -87,14 +88,22 @@ class puppet (
   }
 
   $ini_settings = {
-    'server'              => { setting => 'server', value => $server,},
-    'ca_server'           => { setting => 'ca_server', value => $ca_server,},
-    'certname'            => { setting => 'certname', value => $certname,},
-    'environment'         => { setting => 'environment', value => $env,},
-    'trusted_node_data'   => { setting => 'trusted_node_data', value => true,},
-    'graph'               => { setting => 'graph', value => $graph,},
+    'server'            => { setting => 'server', value => $server,},
+    'ca_server'         => { setting => 'ca_server', value => $ca_server,},
+    'certname'          => { setting => 'certname', value => $certname,},
+    'environment'       => { setting => 'environment', value => $env,},
+    'trusted_node_data' => { setting => 'trusted_node_data', value => true,},
+    'graph'             => { setting => 'graph', value => $graph,},
   }
   create_resources('ini_setting', $ini_settings, $ini_defaults)
+
+  if $dns_alt_names != undef {
+    ini_setting { 'dns_alt_names':
+      setting => 'dns_alt_names',
+      value   => $dns_alt_names,
+      *       => $ini_defaults,
+    }
+  }
 
   file { 'puppet_config':
     ensure => 'file',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -2,13 +2,12 @@
 #
 # Manages puppetserver
 #
-class puppet::server(
+class puppet::server (
   Variant[Enum['true', 'false'], Boolean] $ca = false, #lint:ignore:quoted_booleans
   Variant[Array[String, 1], Undef]        $autosign_entries = undef,
   String                                  $sysconfig_path = '/etc/sysconfig/puppetserver',
   String                                  $memory_size = '2g', # only m and g are appropriate for unit
   Optional[String]                        $enc = undef,
-  Optional[String]                        $dns_alt_names = undef,
 ) {
 
   include ::puppet
@@ -47,15 +46,7 @@ class puppet::server(
     $ini_enc_settings = {}
   }
 
-  if $dns_alt_names != undef {
-    $ini_dns_alt_names_settings = {
-      'dns_alt_names' => { setting => 'dns_alt_names', value => $dns_alt_names },
-    }
-  } else {
-    $ini_dns_alt_names_settings = {}
-  }
-
-  $ini_settings_merged = $non_conditional_ini_settings + $ini_enc_settings + $ini_dns_alt_names_settings
+  $ini_settings_merged = $non_conditional_ini_settings + $ini_enc_settings
   create_resources('ini_setting', $ini_settings_merged, $ini_defaults)
 
   # Ensure that puppet.conf settings in [main] also trigger a restart of

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -61,6 +61,8 @@ describe 'puppet' do
         end
       end
 
+      it { should_not contain_ini_setting('dns_alt_names') }
+
       it do
         should contain_file('puppet_config').with({
           :ensure  => 'file',
@@ -187,7 +189,7 @@ describe 'puppet' do
   end
 
   describe 'with puppet.conf ini setting' do
-    %w(server ca_server certname graph).each do |setting|
+    %w(server ca_server certname graph dns_alt_names).each do |setting|
       context "#{setting} set to a valid entry" do
         # 'true' is used because it is acceptable to all of the above
         # parameters. Some of the settings are strings and some are boolean and
@@ -266,7 +268,7 @@ describe 'puppet' do
         :message => 'Error while evaluating a Resource Statement',
       },
       'strings' => {
-        :name    => %w(certname cron_command server ca_server env),
+        :name    => %w(certname cron_command server ca_server dns_alt_names env),
         :valid   => ['string'],
         :invalid => [true, %w(array), { 'ha' => 'sh' }, 3, 2.42],
         :message => 'Error while evaluating a Resource Statement',

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -36,7 +36,7 @@ describe 'puppet::server' do
         end
       end
 
-      %w(node_terminus external_nodes dns_alt_names).each do |setting|
+      %w(node_terminus external_nodes).each do |setting|
         it { should_not contain_ini_setting(setting) }
       end
 
@@ -132,24 +132,6 @@ describe 'puppet::server' do
     end
   end
 
-  describe 'with dns_alt_names' do
-    context 'set to a valid path' do
-      let(:params) { { :dns_alt_names => 'foo,foo1,foo1.example.com,foo.example.com' } }
-
-      it do
-        should contain_ini_setting('dns_alt_names').with({
-          :ensure  => 'present',
-          :setting => 'dns_alt_names',
-          :value   => 'foo,foo1,foo1.example.com,foo.example.com',
-          :path    => '/etc/puppetlabs/puppet/puppet.conf',
-          :section => 'master',
-          :require => 'File[puppet_config]',
-          :notify  => 'Service[puppetserver]',
-        })
-      end
-    end
-  end
-
   describe 'with autosign_entries' do
     context 'set to a valid array of strings' do
       let(:params) { { :autosign_entries => ['*.example.org', '*.dev.example.org'] } }
@@ -177,12 +159,6 @@ describe 'puppet::server' do
         :name    => %w(ca),
         :valid   => [true, 'true', false, 'false'],
         :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42],
-        :message => 'Error while evaluating a Resource Statement',
-      },
-      'strings' => {
-        :name    => %w(dns_alt_names),
-        :valid   => ['string'],
-        :invalid => [true, %w(array), { 'ha' => 'sh' }, 3, 2.42],
         :message => 'Error while evaluating a Resource Statement',
       },
       'non-empty array of strings' => {


### PR DESCRIPTION
This change will require a major version change as it will break
compatibility.

It manages a setting in the main section, which is on the agent side and
should not have been specified in the master section which happens with
the puppet::server class.