### PR TITLE
convert client certificate hostnames to lowercase

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@ class puppet (
   $ini_settings = {
     'server'              => { setting => 'server', value => $server,},
     'ca_server'           => { setting => 'ca_server', value => $ca_server,},
-    'certname'            => { setting => 'certname', value => $certname,},
+    'certname'            => { setting => 'certname', value => downcase($certname),},
     'environment'         => { setting => 'environment', value => $env,},
     'trusted_node_data'   => { setting => 'trusted_node_data', value => true,},
     'graph'               => { setting => 'graph', value => $graph,},


### PR DESCRIPTION
in some edge cases :fqdn can contain capital letters which will cause the following error 

> Error: Could not initialize global default settings: Certificate names must be lower case; see #1168

This change lowercases cert name 