### PR TITLE
Add possibility to manage any additional puppet.conf settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@ The absolute path to the puppet agent sysconfig file.
 
 - *Default*: '/etc/sysconfig/puppet'
 
+---
+#### custom_settings (type: Hash)
+A hash that allows you to define and set any settings in puppet.conf.
+For each setting use a nested hash and provide the section and the name
+and value of the setting.
+
+- *Default*: {}
+
+##### Example:
+```
+$custom_settings = {
+  'name'  => { 'section' => 'master', 'setting' => 'codedir', 'value' => '/specific/path' },
+  'other' => { 'section' => 'agent',  'setting' => 'server',  'value' => 'specific.server.local' },
+}
+```
+
 ## Class `puppet::server`
 
 Manages the puppetserver.

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ appending '--noop' to the `cron_command` parameter.
 #### cron_command (type: String)
 Command that will be run from cron for the puppet agent.
 
-- *Default*: '/opt/puppetlabs/bin/puppet agent --onetime --ignorecache
-  --no-daemonize --no-usecacheonfailure --detailed-exitcodes --no-splay'
+- *Default*: '/opt/puppetlabs/bin/puppet agent --onetime --no-daemonize
+  --no-usecacheonfailure --detailed-exitcodes --no-splay'
 
 ---
 #### run_at_boot (type: Variant[Enum['true', 'false'], Boolean])

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class puppet (
   String                                  $env = $environment,
   Variant[Enum['true', 'false'], Boolean] $graph = false, #lint:ignore:quoted_booleans
   String                                  $agent_sysconfig_path = '/etc/sysconfig/puppet',
+  Hash                                    $custom_settings = {},
 ) {
 
   if $config_path != undef {
@@ -95,6 +96,7 @@ class puppet (
     'graph'               => { setting => 'graph', value => $graph,},
   }
   create_resources('ini_setting', $ini_settings, $ini_defaults)
+  create_resources('ini_setting', $custom_settings, $ini_defaults)
 
   file { 'puppet_config':
     ensure => 'file',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -251,6 +251,37 @@ describe 'puppet' do
     end
   end
 
+  describe 'with custom_settings specified' do
+    let(:params) { {
+      :custom_settings => {
+        'codedir' => { 'section' => 'master', 'setting' => 'codedir', 'value' => '/spec/testing' },
+        'testing' => { 'section' => 'agent',  'setting' => 'server',  'value' => 'spec.test.ing' },
+      }
+    } }
+
+    it do
+      should contain_ini_setting('codedir').with({
+        :ensure  => 'present',
+        :path    => '/etc/puppetlabs/puppet/puppet.conf',
+        :section => 'master',
+        :setting => 'codedir',
+        :value   => '/spec/testing',
+        :require => 'File[puppet_config]',
+      })
+    end
+
+    it do
+      should contain_ini_setting('testing').with({
+        :ensure  => 'present',
+        :path    => '/etc/puppetlabs/puppet/puppet.conf',
+        :section => 'agent',
+        :setting => 'server',
+        :value   => 'spec.test.ing',
+        :require => 'File[puppet_config]',
+      })
+    end
+  end
+
   describe 'parameter type and content validations' do
     validations = {
       'absolute paths' => {
@@ -264,6 +295,12 @@ describe 'puppet' do
         :valid   => [true, 'true', false, 'false'],
         :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42],
         :message => 'Error while evaluating a Resource Statement',
+      },
+      'hash' => {
+        :name    => %w(custom_settings),
+        :valid   => [], # valid hashes are to complex to block test them here
+        :invalid => ['string', %w(array), 3, 2.42, true, nil],
+        :message => 'expects a Hash value',
       },
       'strings' => {
         :name    => %w(certname cron_command server ca_server env),


### PR DESCRIPTION
This patch allows to specify any setting in any section in puppet.conf.

Example:

```
$free_settings = {
  'codedir' => { setting => 'codedir', 'section' => 'master', value => '/specific/path/code',},
}
```
successor of https://github.com/ghoneycutt/puppet-module-puppet/pull/137

Sorry for sneaking in a README fix for the ignorecache setting.